### PR TITLE
http->https リダイレクト

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteCond %{HTTPS} off
+RewriteCond %{HTTP_HOST} oucrc.net
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]


### PR DESCRIPTION
gitのテストも兼ね，.htaccessを追加し，
アドレスバーに「oucrc.net」と検索した場合にhttpsにリダイレクトされるようにしました．
さくらサーバ  ライトプランのhtaccess対応は確認済みです．
また，localhostなどのテスト環境ではリダイレクトされないようにしてます．