### PR TITLE
update: Twitterアカウントへのリンクを正規化

### DIFF
--- a/src/components/Contents.vue
+++ b/src/components/Contents.vue
@@ -163,9 +163,9 @@
         },
         methods: {
             HTMLComment(value) {
+                value = value.replace(/https?:\/\/(?:mobile\.)?twitter\.com\/@?([\w\W_]+)/g, '@$1');
                 value = value.replace(/https?:\/\/[\w!?/\-_~=;.:,*&@#$%()'[\]]+/g, '<a href="$&">$&</a>');
-                value = value.replace(/@[\w\W_]+/g, '<a href="https://twitter.com/$&">$&</a>');
-                //value = value.replace(/(?<=https:\/\/twitter.com\/)@+/g, ''); Safari で実行できない（評価の有無にかかわらずコードが存在していると落ちるっぽいので一旦コメントアウト）
+                value = value.replace(/@([\w\W_]+)/g, '<a href="https://twitter.com/$1">$&</a>');
                 return value;
             },
         }


### PR DESCRIPTION
`http://mobile.twitter.com/@twitter` や `@twitter` などを `<a href="https://twitter.com/twitter">@twitter</a>` の形に正規化します

正規表現のグルーピング `(?:hoge)` を使ってるので例によってSafariだめかも知れません…[MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Regular_Expressions)には対応状況が書いてませんでした